### PR TITLE
Optimize spawner loading to ease chunk load spikes

### DIFF
--- a/src/main/java/mc/rellox/spawnermeta/spawner/generator/GeneratorRegistry.java
+++ b/src/main/java/mc/rellox/spawnermeta/spawner/generator/GeneratorRegistry.java
@@ -4,9 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
@@ -77,15 +75,14 @@ public final class GeneratorRegistry implements Listener {
 	}
 	
 	public static void load() {
-		try {
-			Bukkit.getWorlds()
-			.stream()
-			.map(GeneratorRegistry::get)
-			.filter(Objects::nonNull)
-			.forEach(SpawnerWorld::load);
-		} catch (Exception e) {
-			RF.debug(e);
-		}
+                try {
+                        for(World world : Bukkit.getWorlds()) {
+                                SpawnerWorld sw = get(world);
+                                if(sw != null) sw.load();
+                        }
+                } catch (Exception e) {
+                        RF.debug(e);
+                }
 	}
 	
 	public static void reload() {
@@ -98,13 +95,14 @@ public final class GeneratorRegistry implements Listener {
 	}
 	
 	public static int active(World world) {
-		if(world == null) return SPAWNERS.values()
-				.stream()
-				.mapToInt(SpawnerWorld::active)
-				.sum();
-		if(Settings.inactive(world) == true) return 0;
-		return get(world).active();
-	}
+                if(world == null) {
+                        int sum = 0;
+                        for(SpawnerWorld sw : SPAWNERS.values()) sum += sw.active();
+                        return sum;
+                }
+                if(Settings.inactive(world) == true) return 0;
+                return get(world).active();
+        }
 
 	private static SpawnerWorld get(World world) {
 		if(Settings.inactive(world) == true) return null;
@@ -129,15 +127,14 @@ public final class GeneratorRegistry implements Listener {
 	}
 	
 	public static List<IGenerator> list(World world) {
-		if(world != null) {
-			SpawnerWorld sw = get(world);
-			return sw == null ? new ArrayList<>()
-					: new ArrayList<>(sw.spawners.values());
-		}
-		return SPAWNERS.values().stream()
-				.flatMap(SpawnerWorld::stream)
-				.collect(Collectors.toList());
-	}
+                if(world != null) {
+                        SpawnerWorld sw = get(world);
+                        return sw == null ? new ArrayList<>() : new ArrayList<>(sw.spawners.values());
+                }
+                List<IGenerator> list = new ArrayList<>();
+                for(SpawnerWorld sw : SPAWNERS.values()) list.addAll(sw.spawners.values());
+                return list;
+        }
 	
 	public static void update(Block block) {
 		World world = block.getWorld();
@@ -170,15 +167,14 @@ public final class GeneratorRegistry implements Listener {
 	}
 	
 	public static int remove(World world, boolean fully, Predicate<IGenerator> filter) {
-		if(world != null) {
-			if(Settings.inactive(world) == true) return 0;
-			return get(world).remove(fully, filter);
-		}
-		return SPAWNERS.values()
-				.stream()
-				.mapToInt(sw -> sw.remove(fully, filter))
-				.sum();
-	}
+                if(world != null) {
+                        if(Settings.inactive(world) == true) return 0;
+                        return get(world).remove(fully, filter);
+                }
+                int sum = 0;
+                for(SpawnerWorld sw : SPAWNERS.values()) sum += sw.remove(fully, filter);
+                return sum;
+        }
 	
 	public static void clear() {
 		SPAWNERS.values().forEach(SpawnerWorld::clear);

--- a/src/main/java/mc/rellox/spawnermeta/spawner/generator/SpawnerWorld.java
+++ b/src/main/java/mc/rellox/spawnermeta/spawner/generator/SpawnerWorld.java
@@ -1,6 +1,7 @@
 package mc.rellox.spawnermeta.spawner.generator;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
@@ -20,38 +21,41 @@ import mc.rellox.spawnermeta.spawner.ActiveGenerator;
 public class SpawnerWorld {
 	
 	public final World world;
-	protected final Map<Pos, IGenerator> spawners;
-	private final List<IGenerator> queue;
+        protected final Map<Pos, IGenerator> spawners;
+        private final Queue<Block> queue;
+
+        private static final int INIT_PER_TICK = 32;
 	
 	public SpawnerWorld(World world) {
 		this.world = world;
-		this.spawners = Collections.synchronizedMap(new HashMap<>());
-		this.queue = Collections.synchronizedList(new LinkedList<>());
+                this.spawners = Collections.synchronizedMap(new HashMap<>());
+                this.queue = new ConcurrentLinkedQueue<>();
 	}
 	
-	public Stream<IGenerator> stream() {
-		return spawners.values().stream();
-	}
-	
-	public void load() {
-		Stream.of(world.getLoadedChunks()).forEach(this::load);
-	}
-	
-	public void load(Chunk chunk) {
-		Stream.of(chunk.getTileEntities())
-		.filter(CreatureSpawner.class::isInstance)
-		.map(BlockState::getBlock)
-		.filter(block -> Settings.settings.ignored(block) == false)
-		.map(ISpawner::of)
-		.map(ActiveGenerator::new)
-		.forEach(queue::add);
-	}
-	
-	public void unload(Chunk chunk) {
-		spawners.values().stream()
-		.filter(g -> g.in(chunk))
-		.forEach(g -> g.remove(false));
-	}
+        public Stream<IGenerator> stream() {
+                return spawners.values().stream();
+        }
+
+        public void load() {
+                Chunk[] chunks = world.getLoadedChunks();
+                for(Chunk chunk : chunks) load(chunk);
+        }
+
+        public void load(Chunk chunk) {
+                for(BlockState state : chunk.getTileEntities()) {
+                        if(state instanceof CreatureSpawner) {
+                                Block block = state.getBlock();
+                                if(Settings.settings.ignored(block) == false) queue.add(block);
+                        }
+                }
+        }
+
+        public void unload(Chunk chunk) {
+                for(IGenerator g : spawners.values()) if(g.in(chunk)) g.remove(false);
+                int cx = chunk.getX();
+                int cz = chunk.getZ();
+                queue.removeIf(b -> (b.getX() >> 4) == cx && (b.getZ() >> 4) == cz);
+        }
 
 	public void clear() {
 		spawners.values().forEach(IGenerator::clear);
@@ -67,16 +71,21 @@ public class SpawnerWorld {
 	}
 	
 	public void control() {
-		spawners.values().forEach(IGenerator::control);
-	}
-	
-	public void tick() {
-		if(queue.isEmpty() == false) {
-			queue.forEach(this::put);
-			queue.clear();
-		}
-		spawners.values().forEach(IGenerator::tick);
-	}
+                spawners.values().forEach(IGenerator::control);
+        }
+
+        public void tick() {
+                int i = 0;
+                Block block;
+                while(i < INIT_PER_TICK && (block = queue.poll()) != null) {
+                        if(block.getType() != Material.SPAWNER) continue;
+                        if(Settings.settings.ignored(block) == true) continue;
+                        if(!block.getWorld().isChunkLoaded(block.getX() >> 4, block.getZ() >> 4)) continue;
+                        put(new ActiveGenerator(ISpawner.of(block)));
+                        i++;
+                }
+                spawners.values().forEach(IGenerator::tick);
+        }
 
 	public void reduce() {
 		List<Pos> toRemove = new ArrayList<>();


### PR DESCRIPTION
## Summary
- Replace stream-heavy chunk scans with simple loops and a concurrent queue
- Gradually initialize spawners (32 per tick) to reduce onChunkLoad spikes
- Drop stream usage in generator registry for lower overhead

## Testing
- `mvn -q -e -DskipTests package` *(fails: Non-resolvable import POM: com.intellectualsites.bom:bom-newest:pom:1.52)*

------
https://chatgpt.com/codex/tasks/task_e_68be05baf058832fa4a3c3bfa570780b